### PR TITLE
Fix eslint diagnostics error with none-ls extras

### DIFF
--- a/nvim/lua/user/lsp/none-ls.lua
+++ b/nvim/lua/user/lsp/none-ls.lua
@@ -4,18 +4,24 @@ if not null_ls_status_ok then
 end
 
 local sources = {
-	null_ls.builtins.formatting.stylua,
-	null_ls.builtins.formatting.prettier,
+        null_ls.builtins.formatting.stylua,
+        null_ls.builtins.formatting.prettier,
 }
 
 -- prefer eslint_d if available, else fall back to eslint
-local eslint = null_ls.builtins.diagnostics.eslint_d
-if not eslint then
-	eslint = null_ls.builtins.diagnostics.eslint
+-- these diagnostics were moved to none-ls-extras, so try loading them from there
+local eslint
+local ok, builtin = pcall(require, "none-ls.diagnostics.eslint_d")
+if not ok then
+        ok, builtin = pcall(require, "none-ls.diagnostics.eslint")
+end
+
+if ok then
+        eslint = builtin
 end
 
 if eslint then
-	table.insert(sources, eslint)
+        table.insert(sources, eslint)
 end
 
 local augroup = vim.api.nvim_create_augroup("LspFormatting", {})

--- a/nvim/lua/user/plugins.lua
+++ b/nvim/lua/user/plugins.lua
@@ -43,6 +43,7 @@ return require("lazy").setup({
     "williamboman/mason-lspconfig.nvim",
     "tamago324/nlsp-settings.nvim",
     "nvimtools/none-ls.nvim",
+    "nvimtools/none-ls-extras.nvim",
     {
       "folke/noice.nvim",
       dependencies = { "MunifTanjim/nui.nvim", "rcarriga/nvim-notify" },


### PR DESCRIPTION
## Summary
- load eslint diagnostics from none-ls-extras plugin
- include none-ls-extras plugin in lazy setup

## Testing
- ⚠️ `stylua nvim/lua/user/lsp/none-ls.lua nvim/lua/user/plugins.lua` *(command not found)*
- ⚠️ `luacheck nvim/lua/user/lsp/none-ls.lua nvim/lua/user/plugins.lua` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5ce82a808320801998ac8b7b45ea